### PR TITLE
Feature/cpp 59 newsletter page

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -25,8 +25,13 @@ const config: GatsbyConfig = {
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     `gatsby-plugin-image`,
-    `gatsby-transformer-remark`,
     `gatsby-transformer-json`,
+    {
+      resolve: `gatsby-transformer-remark`,
+      options: {
+        plugins: [`gatsby-plugin-remark_local`],
+      },
+    },
     {
       resolve: `gatsby-source-filesystem`,
       options: {
@@ -76,6 +81,14 @@ const config: GatsbyConfig = {
           },
           {
             singularName: 'post',
+            pluginOptions: {
+              i18n: {
+                locale: 'all',
+              },
+            },
+          },
+          {
+            singularName: 'newsletter',
             pluginOptions: {
               i18n: {
                 locale: 'all',

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"gatsby-transformer-remark": "^6.5.0",
 		"gatsby-transformer-sharp": "^5.4.0",
 		"i18next": "^22.4.9",
+		"is-whitespace-character": "^2.0.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-helmet": "^6.1.0",

--- a/plugins/gatsby-plugin-remark_local/index.js
+++ b/plugins/gatsby-plugin-remark_local/index.js
@@ -1,0 +1,30 @@
+const visit = require('unist-util-visit');
+const toString = require('mdast-util-to-string');
+
+const DOUBLE = '==';
+
+module.exports = async ({ markdownAST }) => {
+  visit(markdownAST, 'text', node => {
+    // Grab the innerText of the heading node
+    let text = toString(node);
+
+    if (
+      text.substring(0, 2) !== DOUBLE ||
+      text.substring(text.length - 2, text.length) !== DOUBLE
+    ) {
+      return;
+    }
+
+    const html = `
+        <mark>
+          ${text.substring(2, text.length - 2)}
+        </mark>
+      `;
+
+    node.type = 'html';
+    node.children = undefined;
+    node.value = html;
+  });
+
+  return markdownAST;
+};

--- a/plugins/gatsby-plugin-remark_local/package.json
+++ b/plugins/gatsby-plugin-remark_local/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "gatsby-plugin-remark",
+  "version": "1.0.0",
+  "description": "Custom remark nodes",
+  "author": {
+    "name": "Michele Moio",
+    "email": "michele.moio@protonmail.com"
+  },
+  "keywords": [
+    "gatsby",
+    "strapi",
+    "gatsby-plugin",
+    "gatsby-source",
+    "strapi-plugin",
+    "strapi-plugin-navigation",
+    "gatsby-remark-transformer"
+  ],
+  "dependencies": {
+    "mdast-util-to-string": "^3.1.1",
+    "unist-util-visit": "^2"
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "gatsby": "^2.29.1",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
+  }
+}

--- a/snapshot.gql
+++ b/snapshot.gql
@@ -1,4 +1,4 @@
-### Type definitions saved at 2023-02-07T10:27:14.035Z ###
+### Type definitions saved at 2023-02-09T07:13:18.124Z ###
 
 enum RemoteFileFit {
   COVER
@@ -679,7 +679,7 @@ type MarkdownWordCount {
   words: Int
 }
 
-type MarkdownRemark implements Node @childOf(mimeTypes: ["text/markdown", "text/x-markdown"], types: ["STRAPI__COMPONENT_SHARED_BLOCK_INTRO_BODY_TEXTNODE", "STRAPI_PRESS_RELEASE_BODY_TEXTNODE", "STRAPI_POST_BODY_TEXTNODE", "STRAPI_EVENT_BODY_TEXTNODE"]) @derivedTypes @dontInfer {
+type MarkdownRemark implements Node @childOf(mimeTypes: ["text/markdown", "text/x-markdown"], types: ["STRAPI__COMPONENT_SHARED_BLOCK_INTRO_BODY_TEXTNODE", "STRAPI_PRESS_RELEASE_BODY_TEXTNODE", "STRAPI_POST_BODY_TEXTNODE", "STRAPI_NEWSLETTER_BODY_TEXTNODE", "STRAPI_EVENT_BODY_TEXTNODE"]) @derivedTypes @dontInfer {
   frontmatter: MarkdownRemarkFrontmatter
   excerpt: String
   rawMarkdownBody: String
@@ -859,6 +859,55 @@ type STRAPI_POST implements Node @derivedTypes @dontInfer {
 
 type STRAPI_POSTBody {
   data: STRAPI_POST_BODY_TEXTNODE @link(by: "id", from: "data___NODE")
+}
+
+type STRAPI_NEWSLETTER_BODY_TEXTNODE implements Node @dontInfer {
+  body: String
+}
+
+type STRAPI_NEWSLETTER implements Node @derivedTypes @dontInfer {
+  title: String
+  eyelet: String
+  bannerNewsletter: Boolean
+  body: STRAPI_NEWSLETTERBody
+  slug: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  publishedAt: Date @dateformat
+  url_path_id: String
+  locale: String
+  url_path: String
+  featuredImage: STRAPI__MEDIA @link(by: "id", from: "featuredImage___NODE")
+  strapi_id: Int
+}
+
+type STRAPI_NEWSLETTERBody @derivedTypes {
+  medias: [STRAPI_NEWSLETTERBodyMedias]
+  data: STRAPI_NEWSLETTER_BODY_TEXTNODE @link(by: "id", from: "data___NODE")
+}
+
+type STRAPI_NEWSLETTERBodyMedias @derivedTypes {
+  alternativeText: String
+  url: String
+  src: String
+  localFile: File @link(by: "id", from: "localFile___NODE")
+  file: STRAPI_NEWSLETTERBodyMediasFile
+}
+
+type STRAPI_NEWSLETTERBodyMediasFile {
+  id: Int
+  name: String
+  alternativeText: String
+  width: Int
+  height: Int
+  hash: String
+  ext: String
+  mime: String
+  size: Float
+  url: String
+  provider: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
 }
 
 type STRAPI_JOBPOSITION implements Node @derivedTypes @dontInfer {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ const IndexPage = () => (
       <Link to="jobpositions">Jobpositions</Link>
       <Link to="media/comunicati-stampa">comunicati stampa</Link>
       <Link to="media/news-ed-eventi">news ed eventi</Link>
+      <Link to="media/newsletter">newsletter</Link>
     </div>
   </Layout>
 );

--- a/src/pages/media/newsletter-outer-space/{StrapiNewsletter.slug}.tsx
+++ b/src/pages/media/newsletter-outer-space/{StrapiNewsletter.slug}.tsx
@@ -1,0 +1,119 @@
+import { graphql, PageProps } from 'gatsby';
+import {GatsbyImage, getImage, IGatsbyImageData, ImageDataLike} from 'gatsby-plugin-image';
+import { useTranslation } from 'gatsby-plugin-react-i18next/dist';
+import React from 'react';
+import { NewsletterBanner } from '../../../components/NewsletterBanner';
+import { SharedBlockBody } from '../../../components/SharedBlockBody';
+import { Layout } from '../../../partials/Layout';
+
+export const query = graphql`
+  fragment NewsletterIntro on STRAPI_NEWSLETTER {
+    eyelet
+    title
+  }
+  query StrapiNewsletter($id: String) {
+    strapiNewsletter(id: { eq: $id }) {
+      id
+      slug
+      url_path
+      publishedAt
+      bannerNewsletter
+      ...NewsletterIntro
+      body {
+        data {
+          id
+          childMarkdownRemark {
+            html
+          }
+        }
+      }
+      featuredImage {
+        url
+        alternativeText
+        localFile {
+          childImageSharp {
+            gatsbyImageData(layout: CONSTRAINED)
+          }
+        }
+      }
+    }
+  }
+`;
+
+const Intro = ({ eyelet, title }: Queries.NewsletterIntroFragment) => {
+  return (
+    <header className="block --block-intro intro">
+      <div className="container-fluid">
+        <div className="row">
+          <div className="col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+            <div className="intro__heading">
+              <h4>{eyelet}</h4>
+              <h1>{title}</h1>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default function Component({
+  data: { strapiNewsletter },
+}: PageProps<Queries.StrapiNewsletterQuery>) {
+  const { publishedAt, eyelet, title, body, bannerNewsletter, featuredImage } =
+    strapiNewsletter || {};
+
+  const {
+    i18n: { language },
+  } = useTranslation();
+
+  if (publishedAt && eyelet && title && body && featuredImage) {
+    const dateOptions: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    };
+    const theDate = new Date(publishedAt).toLocaleDateString(
+      language,
+      dateOptions
+    );
+
+    return (
+      <Layout>
+        <article className="post-article">
+          <Intro eyelet={eyelet} title={title} />
+
+          <div className="post-article__body">
+            <div className="container-fluid">
+              {featuredImage?.localFile?.childImageSharp?.gatsbyImageData && (
+                  <figure className="post-article__visual">
+                    <div className="row">
+                      <div className="col-12 col-lg-10 offset-lg-1 d-flex align-items-center justify-content-center">
+                        <GatsbyImage
+                          image={
+                            getImage(
+                              featuredImage.localFile as ImageDataLike
+                            ) as IGatsbyImageData
+                          }
+                          alt={featuredImage.alternativeText || 'featuredImage'}
+                        />
+                      </div>
+                    </div>
+                  </figure>
+                )}
+              <div className="row">
+                <div className="col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+                  <h4>{theDate}</h4>
+                  <SharedBlockBody data={body} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+        {bannerNewsletter && <NewsletterBanner />}
+      </Layout>
+    );
+  }
+
+  return null;
+}

--- a/src/pages/media/newsletter/index.tsx
+++ b/src/pages/media/newsletter/index.tsx
@@ -1,0 +1,52 @@
+import { graphql, Link } from 'gatsby';
+import { useTranslation } from 'gatsby-plugin-react-i18next/dist';
+import React from 'react';
+import { Layout } from '../../../partials/Layout';
+
+export const query = graphql`
+  query AllNewsletter($language: String!) {
+    allStrapiNewsletter(filter: { locale: { eq: $language } }) {
+      edges {
+        node {
+          id
+          slug
+          bannerNewsletter
+          eyelet
+          title
+          url_path
+          body {
+            data {
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const Newsletter = ({ data }: { data: Queries.AllNewsletterQuery }) => {
+  const {
+    i18n: { language },
+  } = useTranslation();
+
+  return (
+    <Layout>
+      <ul>
+        {data.allStrapiNewsletter.edges.map(({ node: pressRelease }) => (
+          <Link
+            key={pressRelease?.id}
+            to={
+              `${process.env.API_URL}/media/newsletter-outer-space/${pressRelease?.slug}` ||
+              '/#'
+            }
+          >
+            <div className="p-4">{pressRelease.title}</div>
+          </Link>
+        ))}
+      </ul>
+    </Layout>
+  );
+};
+
+export default Newsletter;

--- a/src/sass/_reset.sass
+++ b/src/sass/_reset.sass
@@ -21,27 +21,27 @@ details, summary,
 fieldset, form, label, legend,
 table, caption,
 tbody, tfoot, thead,
-tr, th, td 
+tr, th, td
   margin: 0
   padding: 0
   border: 0
 
 // Typography
 
-html 
+html
   font-size: 62.5%
 
-body 
+body
   font-size: 1.6rem
   line-height: 1.4
 
-* 
+*
   font-family: inherit
   font-size: inherit
   line-height: inherit
 
 a,
-a:visited 
+a:visited
   color: inherit
 
 // Layout
@@ -55,38 +55,38 @@ section,
 main
   display: block
 
-* 
+*
   box-sizing: border-box
 
 *:before,
-*:after 
+*:after
   box-sizing: inherit
 
 // Elements
 
-table 
+table
   border-collapse: collapse
   border-spacing: 0
 
 ol,
-ul 
+ul
   list-style: none
 
 img,
-video 
+video
   max-width: 100%
 
-img 
+img
   border-style: none
 
 blockquote,
-q 
+q
   quotes: none
 
 blockquote:after,
 blockquote:before,
 q:after,
-q:before 
+q:before
   content: ""
   content: none
 
@@ -98,7 +98,7 @@ button
 
 // Attributes & states
 
-[hidden] 
+[hidden]
   display: none !important
 
 [disabled]

--- a/src/sass/_typography.sass
+++ b/src/sass/_typography.sass
@@ -128,7 +128,6 @@ a
 
     &[href^="#"]
       font-weight: 500
-      text-decoration: underline
 
   p[style*="center"]
       line-height: 2.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -6676,6 +6676,11 @@ is-weakset@^2.0.1:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+is-whitespace-character@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-2.0.1.tgz#6521b229f9fcfb306b22997c15cf9561fdb6dfc6"
+  integrity sha512-gkZdE/Vz5z7fnE03FRp4BUdLAqycmm7Yd36vsyvEX8YmBYtAiCVwEnKNg5BxXBfpJ3aK6RmokQD6RNBN9smXiA==
+
 is-windows@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"


### PR DESCRIPTION
This pr adds:

- Basic newsletter listing with routing
- Newsletter single page
- A local remark plugin to tranform text enclosed in == symbols to <mark> elements
- Some styling