### PR TITLE
[CPP-135] Index Redirect

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -74,7 +74,7 @@ const config: GatsbyConfig = {
         matomoUrl: 'https://pagopa.matomo.cloud',
         matomoJsScript: 'matomo.js',
         matomoPhpScript: 'matomo.php',
-        siteUrl: 'https://www.pagopa.it'
+        siteUrl: 'https://www.pagopa.it',
       },
     },
     {
@@ -233,6 +233,13 @@ const config: GatsbyConfig = {
         languages: ['it'],
         fallbackLanguage: 'it',
         generateDefaultLanguagePage: true,
+        pages: [
+          {
+            matchPath: '/:lang?',
+            getLanguageFromPath: true,
+            excludeLanguages: ['it', 'en'],
+          },
+        ],
       },
     },
   ],


### PR DESCRIPTION
## Description
Excludes path ending with a lang code from the i18n redirect, making possible to use a lang code as the slug for the index page.

Fixes # [cpp-135](https://pagopa.atlassian.net/jira/software/projects/CPP/boards/278?selectedIssue=CPP-135)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Visual testing
