### PR TITLE
[SELC-3081] Newsletter ordering from newest to latest

### DIFF
--- a/src/components/SharedBlocks/Newsletter/NewsletterList.tsx
+++ b/src/components/SharedBlocks/Newsletter/NewsletterList.tsx
@@ -33,7 +33,7 @@ export const NewsletterList = () => {
       }
     }
     query AllNewsletter {
-      allStrapiNewsletter {
+      allStrapiNewsletter(sort: { publishedAt: DESC }) {
         nodes {
           ...Newsletter
         }


### PR DESCRIPTION
## Description
Modifies graphQl query show newsletters components in descending order.

Fixes # [selc-3081](https://pagopa.atlassian.net/browse/SELC-3081)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Visual testing
